### PR TITLE
Only every return None

### DIFF
--- a/pyrow/response.py
+++ b/pyrow/response.py
@@ -230,17 +230,17 @@ class Response(object):  # pylint: disable=R0904
     def get_workout_state(self):
         if 'CSAFE_PM_GET_WORKOUTSTATE' in list(self.__results.keys()):
             return self.__results['CSAFE_PM_GET_WORKOUTSTATE'][0]
-        return 0
+        return None
 
     def get_workout_int_type(self):
         if 'CSAFE_PM_GET_INTERVALTYPE' in list(self.__results.keys()):
             return self.__results['CSAFE_PM_GET_INTERVALTYPE'][0]
-        return 0
+        return None
 
     def get_workout_int_count(self):
         if 'CSAFE_PM_GET_WORKOUTINTERVALCOUNT' in list(self.__results.keys()):
             return self.__results['CSAFE_PM_GET_WORKOUTINTERVALCOUNT'][0]
-        return 0
+        return None
 
     def get_erg_mfgid(self):
         if 'CSAFE_GETVERSION_CMD' in list(self.__results.keys()):


### PR DESCRIPTION
To return two different types from the same API could be confusing.
Instead, the consumer should deal with the return type.